### PR TITLE
New method for deducing chart size

### DIFF
--- a/bar_chart.coffee
+++ b/bar_chart.coffee
@@ -1,6 +1,13 @@
 class Dashing.BarChart extends Dashing.Widget
 
   ready: ->
+    container = $(@node).parent()
+    width = (Dashing.widget_base_dimensions[0] * container.data("sizex")) + Dashing.widget_margins[0] * 2 * (container.data("sizex") - 1)
+    height = (Dashing.widget_base_dimensions[1] * container.data("sizey")) - 30
+
+    canvas = $(@node).find('.canvas-holder')
+    canvas.append("<canvas width=\"#{width}\" height=\"#{height}\" id=\"chart-area\" class=\"chart-area\"/>")
+
     @ctx = $(@node).find('.chart-area')[0].getContext('2d')
     @myData = {
       labels: @get('labels')

--- a/bar_chart.html
+++ b/bar_chart.html
@@ -1,8 +1,6 @@
 <h1 class="title" data-bind="title"></h1>
 
-<div class="canvas-holder">
-	<canvas id="chart-area" class="chart-area"/>
-</div>
+<div class="canvas-holder"></div>
 
 <p class="more-info" data-bind="moreinfo"></p>
 

--- a/bar_chart.scss
+++ b/bar_chart.scss
@@ -13,10 +13,20 @@ $chart-height:      100%;
 // Widget-bar-chart styles
 // ----------------------------------------------------------------------------
 .widget-bar-chart {
-
   background-color: $background-color;
+  position: relative;
+
+  .canvas-holder {
+    position: absolute;
+    left: 0px;
+    top: 0px;
+  }
 
   .title {
+    left: 0;
+    right: 0;
+    top: 10px;
+    position: absolute;
     color: $title-color;
   }
 
@@ -28,9 +38,6 @@ $chart-height:      100%;
     color: $updateat-color;
   }
 
-  canvas#chart-area.chart-area {
-    width: $chart-width !important;
-    height: $chart-height !important;
-  }
-
+  // canvas#chart-area.chart-area {
+  // }
 }


### PR DESCRIPTION
 Great widget - thanks for creating!

 I've changed how the canvas is created (and the size is deduced) - basically copying the graph widget method.  It's a bit nasty, but it looked like with the current method the bar chart is being resized after creation, which makes it look a bit blurry.

 I've moved the title around a little and left a small bit of padding at the bottom of the graph (to fit the updated text).  The moreinfo text gets obscured, but I don't use that...

 Hope you find this useful.

![bar_chart_before](https://cloud.githubusercontent.com/assets/1655853/12076692/a2be92fc-b1ad-11e5-975a-a4ab5b223eaa.png)

After:

![bar_chart_after](https://cloud.githubusercontent.com/assets/1655853/12076693/ac624826-b1ad-11e5-9ff8-2e44ce190e6c.png)
